### PR TITLE
Switching deprecated OpenSSL::Digest::Digest to OpenSSL::Digest

### DIFF
--- a/lib/mailgun_webhooks/signature.rb
+++ b/lib/mailgun_webhooks/signature.rb
@@ -11,7 +11,7 @@ module MailgunWebhooks
       api_key   = data.fetch('api_key')
       timestamp = data.fetch('timestamp')
       token     = data.fetch('token')
-      digest    = OpenSSL::Digest::Digest.new('sha256')
+      digest    = OpenSSL::Digest.new('sha256')
 
       signature == OpenSSL::HMAC.hexdigest(digest,
                                            api_key,


### PR DESCRIPTION
Deprecated in https://github.com/ruby/ruby/pull/446.  Example of `fog` gem doing the same thing: https://github.com/fog/fog/pull/2473/files.
